### PR TITLE
Fix broken post urls

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -13,6 +13,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/assets/js");
   eleventyConfig.addPassthroughCopy("src/favicon.ico");
   eleventyConfig.addPassthroughCopy("src/analytics.txt");
+  eleventyConfig.addPassthroughCopy("_redirects");
   // eleventyConfig.addPassthroughCopy("source/robots.txt");
 
   eleventyConfig.setDataDeepMerge(true);

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/blog/:year-:month-:date:slug  /blog/:slug
+/blog/:year-:month-:date:slug /blog/:slug

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/blog/:year-:month-:date-:slug /blog/:slug
+/blog/:year-:month-:date-:slug  /blog/:slug

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/blog/:year-:month-:date:slug /blog/:slug
+/blog/:year-:month-:date-:slug /blog/:slug

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/blog/:year-:month-:date:slug  /blog/:slug

--- a/src/_posts/2012-04-12-mobile-vs-desktop-is-a-lie.md
+++ b/src/_posts/2012-04-12-mobile-vs-desktop-is-a-lie.md
@@ -17,7 +17,7 @@ created: 1334217052
 
 <p>As <a href="http://www.kylebean.co.uk/portfolio/#mobileevolution">Kyle Beans excellent russian doll project</a> demonstrated, the definition of "mobile phone" has changed so many times in the past 20 years. I'm sure it's bound to change even more in the next 20.</p>
 
-<p>So what makes a mobile a mobile? No one really knows. They could have small screen, or they could not be. They could have a touch screen, <a href="www.flickr.com/photos/ivyfield/4667604500/">or they could not be.</a> They could be on a slow network connection, <a href="http://www.flickr.com/photos/shanalines/4785508962/">or they could not be.</a> They could be using a colour display, <a href="http://www.flickr.com/photos/alienratt/5580530063/">or they could not be</a>. The rise of "mobile" devices has made it really obvious how broad and varied the web is. All our assumptions get thrown out the (1024 x 768) window.</p>
+<p>So what makes a mobile a mobile? No one really knows. They could have small screen, or they could not be. <a href="http://www.flickr.com/photos/ivyfield/4667604500/">They could have a touch screen, or they could not be.</a> <a href="http://www.flickr.com/photos/shanalines/4785508962/">They could be on a slow network connection, or they could not be.</a> <a href="http://www.flickr.com/photos/alienratt/5580530063/">They could be using a colour display, or they could not be</a>. The rise of "mobile" devices has made it really obvious how broad and varied the web is. All our assumptions get thrown out the (1024 x 768) window.</p>
 
 <p>That's where Responsive Web Design excels.</p>
 

--- a/src/_posts/2014-01-06-2013.md
+++ b/src/_posts/2014-01-06-2013.md
@@ -36,7 +36,7 @@ I've also been working on getting the [Drupal.org theme open-sourced.](https://g
 
 ## Work
 
-I did a lot of work for Comic Relief in 2013, helping them with [Rednoseday.com](www.rednoseday.com) and [Sportrelief.com](www.sportrelief.com) which are behemoths of sites with very complex requirements. I haven't really written much about contracting after doing it for about a year and a half, let's save that for another post. The short story is a I joined [Wunderroot](http://www.wunderroot.co.uk) as a full-time employee and I'm very excited about what 2014 will bring working with them.
+I did a lot of work for Comic Relief in 2013, helping them with [Rednoseday.com](http://www.rednoseday.com) and [Sportrelief.com](http://www.sportrelief.com) which are behemoths of sites with very complex requirements. I haven't really written much about contracting after doing it for about a year and a half, let's save that for another post. The short story is a I joined [Wunderroot](http://www.wunderroot.co.uk) as a full-time employee and I'm very excited about what 2014 will bring working with them.
 
 ## The rest
 

--- a/src/_posts/2015-05-31-100-words.md
+++ b/src/_posts/2015-05-31-100-words.md
@@ -6,4 +6,4 @@ tags: 100 words
 
 Inspired by [Jeremy,](https://adactio.com/) I've started the 100 words challenge. 100 words every day for 100 days. I'm surprised how much I enjoyed reading Jeremy's daily slices of life.
 
-This is day two, and I'm jetlagged with nothing else to write about, so I choose to write about the writing challenge. I don't really know what I'm going to write about everyday but I guess that's part of the fun. I hope it's going to encourage me to work on this site a little more, as I start to use it often. I'm using [Hemingway](www.hemingwayapp.com) to write these posts, it's handy!
+This is day two, and I'm jetlagged with nothing else to write about, so I choose to write about the writing challenge. I don't really know what I'm going to write about everyday but I guess that's part of the fun. I hope it's going to encourage me to work on this site a little more, as I start to use it often. I'm using [Hemingway](http://www.hemingwayapp.com) to write these posts, it's handy!


### PR DESCRIPTION
I noticed that at some point my blog post link structure changed from:
`/blog/year-month-date-slug` to `/blog/slug`

For example:
`/blog/2014-01-03-hello-jekyll` is now `/blog/hello-jekyll`

I'm trying to use Netlify redirects to fix this, but the [placeholder syntax described on this docs page](https://docs.netlify.com/routing/redirects/redirect-options/#placeholders) just doesn't want to work.